### PR TITLE
ドキュメントの見直し（Webアプリ開発のノウハウ - ファイルダウンロード）

### DIFF
--- a/doc/web/file-download/file-download.rst
+++ b/doc/web/file-download/file-download.rst
@@ -6,6 +6,10 @@
 AbstractViewを継承したクラスをSpringのDIコンテナに登録しておくと、 :spring-framework-doc:`BeanNameViewResolver <javadoc-api/org/springframework/web/servlet/view/BeanNameViewResolver.html>` が
 Controllerから返却されたBean名と一致する場合に、Viewとして選択してくれます。
 
+.. tip::
+
+  Spring Web MVCやThymeleafでは、Controllerから返却された値に対応するViewを解決するため、いくつかのViewResolverが提供されています。Spring Bootを使用する場合、これらのViewResolverは自動で構成され、優先度の高いViewResolverから使用されます。Spring Web MVCが提供しているものについては :spring-framework-doc:`View Resolution <reference/html/web.html#mvc-viewresolver>` を、Thymeleafが提供しているものについては :thymeleaf-tutorials-doc:`Views and View Resolvers <thymeleafspring.html#views-and-view-resolvers>` を参照してください。
+
 以下のサンプルコードの動作確認環境については、 :ref:`test-environment-and-dependencies` を参照してください。
 
 処理フロー
@@ -13,16 +17,6 @@ Controllerから返却されたBean名と一致する場合に、Viewとして�
 1. Controllerはファイルのダウンロード処理を実施するカスタムViewクラスのBean名を返却します。(このサンプルではテキストファイルのダウンロード処理を実施するBean名を返却します。)
 2. BeanNameViewResolverは、Controllerから返却されたBean名に一致するカスタムViewクラスを選択します。
 3. カスタムViewクラスは、レスポンスヘッダを設定してダウンロードファイルをレスポンスボディに書込みます。
-
-.. tip::
-
-  Spring Web MVCやThymeleafを使用した場合、デフォルトではInternalResourceViewResolver(JSP用)やThymeleafViewResolver(Thymeleaf用)もViewResolverとして追加されます。
-  Controllerから返却する値は、優先度の高いViewResolverから解決されます。
-
-  優先度(上から高い順)
-    * BeanNameViewResolver
-    * ThymeleafViewResolver
-    * InternalResourceViewResolver
 
 実装例
 --------------------------------------------------

--- a/samples/web/file-download/src/main/java/keel/filedownload/TextFileDownloadView.java
+++ b/samples/web/file-download/src/main/java/keel/filedownload/TextFileDownloadView.java
@@ -1,8 +1,8 @@
 package keel.filedownload;
 
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StreamUtils;
 import org.springframework.web.servlet.view.AbstractView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -20,22 +20,21 @@ public class TextFileDownloadView extends AbstractView {
 
     public TextFileDownloadView(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
+        setContentType("text/plain");
     }
 
     @Override
     protected void renderMergedOutputModel(Map<String, Object> model,
                                            HttpServletRequest request, HttpServletResponse response) throws Exception {
-
-        final FileDownloadAttributes attributes = (FileDownloadAttributes) model.get(DOWNLOAD_FILE_INFO_KEY);
+        // ダウンロード対象のファイルを読込み、レスポンスボディに書込みます
+        FileDownloadAttributes attributes = (FileDownloadAttributes) model.get(DOWNLOAD_FILE_INFO_KEY);
+        Resource downloadFileResource = resourceLoader.getResource(attributes.getTargetFilePath());
+        long size = downloadFileResource.getInputStream().transferTo(response.getOutputStream());
 
         // レスポンスヘッダを設定します
+        response.setContentType(getContentType());
         response.setHeader("Content-Disposition", "attachment; filename=" + attributes.getDownloadFileName());
-        response.setHeader("Content-Type", "text/plain");
-
-        // ダウンロード対象のファイルを読込み、レスポンスボディに書込みます
-        StreamUtils.copy(
-                resourceLoader.getResource(attributes.getTargetFilePath()).getInputStream(),
-                response.getOutputStream());
+        response.setHeader("Content-Length", String.valueOf(size));
     }
 }
 // example-end

--- a/samples/web/file-download/src/main/java/keel/filedownload/TextFileDownloadView.java
+++ b/samples/web/file-download/src/main/java/keel/filedownload/TextFileDownloadView.java
@@ -1,16 +1,17 @@
 package keel.filedownload;
 
-import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.view.AbstractView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
 // example-start
-// @Componentを設定して、コンポーネントスキャン対象にします。
+// @Componentを設定して、コンポーネントスキャン対象にします
 @Component
 public class TextFileDownloadView extends AbstractView {
 
@@ -28,13 +29,18 @@ public class TextFileDownloadView extends AbstractView {
                                            HttpServletRequest request, HttpServletResponse response) throws Exception {
         // ダウンロード対象のファイルを読込み、レスポンスボディに書込みます
         FileDownloadAttributes attributes = (FileDownloadAttributes) model.get(DOWNLOAD_FILE_INFO_KEY);
-        Resource downloadFileResource = resourceLoader.getResource(attributes.getTargetFilePath());
-        long size = downloadFileResource.getInputStream().transferTo(response.getOutputStream());
+        long size = writeFileContentToResponse(attributes.getTargetFilePath(), response);
 
         // レスポンスヘッダを設定します
         response.setContentType(getContentType());
         response.setHeader("Content-Disposition", "attachment; filename=" + attributes.getDownloadFileName());
         response.setHeader("Content-Length", String.valueOf(size));
+    }
+
+    private long writeFileContentToResponse(String filePath, HttpServletResponse response) throws IOException {
+        try (InputStream in = resourceLoader.getResource(filePath).getInputStream()) {
+            return in.transferTo(response.getOutputStream());
+        }
     }
 }
 // example-end

--- a/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
+++ b/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
         // Viewで使用するダウンロードファイルパスをModelに設定します
         // （もしユーザが画面で入力したファイルパス等を使用する場合は、ディレクトリトラバーサル攻撃への対策も考慮してください）
         model.addAttribute(TextFileDownloadView.DOWNLOAD_FILE_INFO_KEY,
-                new FileDownloadAttributes(targetFilePath, "テスト.txt"));
+                new FileDownloadAttributes(targetFilePath, "ダウンロード.txt"));
 
         // ViewのBean名を返します
         return "textFileDownloadView";

--- a/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
+++ b/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
@@ -21,12 +21,12 @@ public class UserController {
     @GetMapping("/download")
     public String download(Model model) {
 
-        // Viewで使用するダウンロードファイルパスをModelに設定します。
+        // Viewで使用するダウンロードファイルパスをModelに設定します
         // （もしユーザが画面で入力したファイルパス等を使用する場合は、ディレクトリトラバーサル攻撃への対策も考慮してください）
         model.addAttribute(TextFileDownloadView.DOWNLOAD_FILE_INFO_KEY,
                 new FileDownloadAttributes(targetFilePath, "download.txt"));
 
-        // ViewのBean名を返します。
+        // ViewのBean名を返します
         return "textFileDownloadView";
     }
     // example-end

--- a/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
+++ b/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
         // Viewで使用するダウンロードファイルパスをModelに設定します
         // （もしユーザが画面で入力したファイルパス等を使用する場合は、ディレクトリトラバーサル攻撃への対策も考慮してください）
         model.addAttribute(TextFileDownloadView.DOWNLOAD_FILE_INFO_KEY,
-                new FileDownloadAttributes(targetFilePath, "download.txt"));
+                new FileDownloadAttributes(targetFilePath, "テスト.txt"));
 
         // ViewのBean名を返します
         return "textFileDownloadView";

--- a/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
+++ b/samples/web/file-download/src/main/java/keel/filedownload/UserController.java
@@ -10,7 +10,7 @@ public class UserController {
 
     /** ダウンロード対象のファイルパス */
     @Value("${keel.filedownload.path}")
-    String targetFilePath;
+    private String targetFilePath;
 
     @GetMapping("/")
     public String index() {
@@ -20,19 +20,13 @@ public class UserController {
     // example-start
     @GetMapping("/download")
     public String download(Model model) {
-        /**
-         * {@link TextFileDownloadView}に渡す情報を、Modelに設定します。
-         *
-         * なお、このサンプルではダウンロード対象のファイルパス({@link targetFilePath})は
-         * application.propertiesから取得していますが、ユーザが画面で入力したファイルパス等を使用する場合は、
-         * ディレクトリトラバーサル攻撃への対策も実施するようにしてください。
-         */
+
+        // Viewで使用するダウンロードファイルパスをModelに設定します。
+        // （もしユーザが画面で入力したファイルパス等を使用する場合は、ディレクトリトラバーサル攻撃への対策も考慮してください）
         model.addAttribute(TextFileDownloadView.DOWNLOAD_FILE_INFO_KEY,
                 new FileDownloadAttributes(targetFilePath, "download.txt"));
-        /**
-         * ダウンロード処理は、{@link TextFileDownloadView}で実施するため、
-         * ここではそのBean名(textFileDownloadView)を返却します。
-         */
+
+        // ViewのBean名を返します。
         return "textFileDownloadView";
     }
     // example-end

--- a/samples/web/file-download/src/test/java/keel/filedownload/UserControllerTest.java
+++ b/samples/web/file-download/src/test/java/keel/filedownload/UserControllerTest.java
@@ -29,7 +29,7 @@ public class UserControllerTest {
                 .andExpect(model().hasNoErrors())
                 .andExpect(content().string("test"))
                 .andExpect(content().contentType("text/plain"))
-                .andExpect(header().string("Content-Disposition",
-                        "attachment; filename*=UTF-8''" + URLEncoder.encode("テスト.txt", StandardCharsets.UTF_8)));
+                .andExpect(header().string("Content-Disposition", "attachment; filename*=UTF-8''"
+                        + URLEncoder.encode("ダウンロード.txt", StandardCharsets.UTF_8)));
     }
 }

--- a/samples/web/file-download/src/test/java/keel/filedownload/UserControllerTest.java
+++ b/samples/web/file-download/src/test/java/keel/filedownload/UserControllerTest.java
@@ -7,6 +7,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -26,6 +29,7 @@ public class UserControllerTest {
                 .andExpect(model().hasNoErrors())
                 .andExpect(content().string("test"))
                 .andExpect(content().contentType("text/plain"))
-                .andExpect(header().string("Content-Disposition", "attachment; filename=download.txt"));
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename*=UTF-8''" + URLEncoder.encode("テスト.txt", StandardCharsets.UTF_8)));
     }
 }


### PR DESCRIPTION
## 概要

## レビュー依頼前のチェックリスト

- [x] 作業時間を記録していること
- [x] セルフレビュー済みであること
- [x] PRに適切なtarget branchを設定済みであること

ソースコード特有の項目

- [x] 理解しづらいコードはコメントで補足説明済みであること
- [x] `./mvn clean verify`を実行して結果が`BUILD SUCCESS`であること

## 動作確認方法

- [x] 生成したHTMLがブラウザで正しく表示されていることを確認

## レビューアに確認して欲しいポイント

- ドキュメントの内容
- サンプルコードの妥当性

## レビューアへの申し送り事項

- ドキュメント
  - Tipsの場所が微妙に思えたので、BeanNameResolverが登場した文脈のところに移動させました
  - Tipsに優先順位が書いてあるのですが、他にもContentNegotiatingViewResolverやViewResolverCompoit等、他のViewReolverも動いていたりもあり、SpringにもThymeleafにも優先順位が明言されているところが見つからなかったため、記載を削除しました
      - 動作させてみたところ、解決は確かにBeanNameResolverではあるのですがトップレベルのBeanNameResoloverではなくContentNegotiatingViewResolverの中で委譲されたBeanNameViewResolverで、全体の順位を書くのも悩ましかったのもあります...
- サンプルコード
  - なぜかメソッド内にJavadocコメント書かれていたので修正しました
  - AbstractViewを継承して標準のファイルダウンロードViewに`AbstractPdfView`や`AbstractXlsView`があったので、見直しにはそれらを参考にしました
  - カスタムViewの説明があればリンクしたかったのですが、公式ドキュメントでは特に言及されている箇所を見つけられなかったのでそのままにしています
  - `Content-Type`の設定をコンストラクタに移していますが、いくつかの基底クラスのメソッド（`writeToResponse`等）で使われていたので、他の子クラスの実装も参考にして変更しました。
  - `Content-Length`の設定は、responseに`setContentLength`メソッドがあるのですが、intの範囲にしか対応していなかったので、文字列で設定するようにしました
    - 仕様的にはサイズ制限が無いらしく問題ないと判断しています（[RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2)）

## その他、気になること

(もしあれば書く)

---

## レビュー後、マージ前のチェックリスト（レビューア用のチェックリスト）

- [ ] レビュー時間を記録していること
- [ ] PRに適切なtarget branchを設定済みであること

---

| 作業分類             |時間(h)|
|------------------|---|
| 実装・執筆            |6|
| レビュー(backpaper0) |0.5|
