### PR TITLE
Spring Bootを2.7.5にバージョンアップ

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -200,10 +200,10 @@ sample_app_base = 'https://github.com/Fintan-contents/spring-crib-notes/tree/' +
 extlinks = {
   'sample-app': (sample_app_base + '/samples/%s', None),
   'spring-framework-doc': ('https://docs.spring.io/spring-framework/docs/' + '5.3.23' + '/%s', None),
-  'spring-boot-doc': ('https://docs.spring.io/spring-boot/docs/' + '2.7.4' + '/%s', None),
+  'spring-boot-doc': ('https://docs.spring.io/spring-boot/docs/' + '2.7.5' + '/%s', None),
   'spring-batch-doc': ('https://docs.spring.io/spring-batch/docs/' + '4.3.7' + '/%s', None),
   'spring-session-doc': ('https://docs.spring.io/spring-session/reference/' + '2.7.0' + '/%s', None),
-  'spring-security-doc': ('https://docs.spring.io/spring-security/reference/' + '5.7.3' + '/%s', None),
+  'spring-security-doc': ('https://docs.spring.io/spring-security/reference/' + '5.7.4' + '/%s', None),
   'macchinetta-server-guideline-thymeleaf-doc': ('https://macchinetta.github.io/server-guideline-thymeleaf/' + '1.8.1.SP1.RELEASE' + '/ja/%s', None),
   'macchinetta-cloud-guideline-doc': ('https://macchinetta.github.io/cloud-guideline/' + '1.2.0.RELEASE' + '/ja/%s', None),
   'macchinetta-batch-guideline-doc': ('https://macchinetta.github.io/batch-guideline/' + '2.3.1.RELEASE' + '/ja/%s', None),

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -34,7 +34,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.5</version>
   </parent>
   <!-- spring-boot-version-end -->
 


### PR DESCRIPTION
Spring Bootのバージョンを`2.7.5`にあげました。

https://github.com/spring-projects/spring-boot/releases/tag/v2.7.5