### PR TITLE
HTMLページタイトルからバージョン表記を除去

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "!layout.html" %}
 
 {% block htmltitle %}
-<title>{{ title|striptags|e }}</title>
+  <title>{{ title|striptags|e }}</title>
 {% endblock %}
 
 {% block extrahead %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,9 +1,5 @@
 {% extends "!layout.html" %}
 
-{% block htmltitle %}
-<title>{{ title|striptags|e }}</title>
-{% endblock %}
-
 {% block extrahead %}
   <script defer data-domain="fintan-content.github.io,all.fintan" src=https://plausible.io/js/script.js></script>
 {% endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "!layout.html" %}
 
 {% block htmltitle %}
-  <title>{{ title|striptags|e }}</title>
+<title>{{ title|striptags|e }}</title>
 {% endblock %}
 
 {% block extrahead %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,5 +1,9 @@
 {% extends "!layout.html" %}
 
+{% block htmltitle %}
+<title>{{ title|striptags|e }}</title>
+{% endblock %}
+
 {% block extrahead %}
   <script defer data-domain="fintan-content.github.io,all.fintan" src=https://plausible.io/js/script.js></script>
 {% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,6 +110,9 @@ html_show_sourcelink = False
 # Custom stylesheet
 html_style = "css/customize-rtd.css"
 
+# バージョン表記を削除するためタイトルを明示
+html_title = project
+
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
## 概要

## レビュー依頼前のチェックリスト

- [x] 作業時間を記録していること
- [x] セルフレビュー済みであること
- [x] PRに適切なtarget branchを設定済みであること

ソースコード特有の項目

- [ ] 理解しづらいコードはコメントで補足説明済みであること
- [ ] `./mvn clean verify`を実行して結果が`BUILD SUCCESS`であること

## 動作確認方法

- [x] HTMLを生成してページタイトルを確認

## レビューアに確認して欲しいポイント

- バージョン表記だけ削除する方法が分からなかったので、各ページタイトルの末尾についている`-- keel-doc 1.0.0 ドキュメント`を除去するようレイアウトを修正しました
  - `titlesuffix`変数で管理されているようなのですが、これだけ指定する方法も分からなかったのでまるっと消しました
  - [使っているThemeのlayout.html](https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/layout.html)

## レビューアへの申し送り事項

(もしあれば書く)

## その他、気になること

(もしあれば書く)

---

## レビュー後、マージ前のチェックリスト（レビューア用のチェックリスト）

- [ ] レビュー時間を記録していること
- [ ] PRに適切なtarget branchを設定済みであること

---

| 作業分類             |時間(h)|
|------------------|---|
| 実装・執筆            |0|
| レビュー(backpaper0) |0|
